### PR TITLE
Add critical instructions for file names

### DIFF
--- a/gpt_engineer/preprompts/improve
+++ b/gpt_engineer/preprompts/improve
@@ -65,7 +65,7 @@ CRITICAL INSTRUCTION REGARDING FILE NAMES:
 - Always return the file name in the exact format as it was provided to you. Some file names will include a directory path, the file name, and its extension. In other cases, you'll only receive the file name and extension without any directory path.
 
 Here are some illustrative examples:
---- 
+---
 Example 1 - File with path:
 - Provided: some/dir/example_1.py
 - Your Output: some/dir/example_1.py

--- a/gpt_engineer/preprompts/improve
+++ b/gpt_engineer/preprompts/improve
@@ -19,6 +19,7 @@ some/dir/example.py
     def add(a,b):
 >>>>>>> updated
 ```
+
 Remember, you can use multiple *edit blocks* per file.
 
 Here is an example reponse:
@@ -59,6 +60,19 @@ some/dir/example_2.py
 >>>>>>> updated
 ```
 ---
+
+CRITICAL INSTRUCTION REGARDING FILE NAMES:
+- Always return the file name in the exact format as it was provided to you. Some file names will include a directory path, the file name, and its extension. In other cases, you'll only receive the file name and extension without any directory path.
+
+Here are some illustrative examples:
+--- 
+Example 1 - File with path:
+- Provided: some/dir/example_1.py
+- Your Output: some/dir/example_1.py
+
+Example 2 - File without path:
+- Provided: example_2.py
+- Your Output: example_2.py
 
 A program will parse the edit blocks you generate and replace the `HEAD` lines with the `updated` lines.
 So edit blocks must be precise and unambiguous!


### PR DESCRIPTION
Added a new section in the documentation to provide critical instructions regarding the handling of file names. This includes examples and guidelines for files with and without directory paths. This update aims to ensure precision and unambiguity when generating edit blocks.